### PR TITLE
[JENKINS-36282] Add support for exporting jobs in folders recursively

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.34</version>
+    <version>2.35</version>
     <relativePath/>
   </parent>
 
@@ -49,13 +49,4 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-
-  <dependencies>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>cloudbees-folder</artifactId>
-      <version>6.1.2</version>
-    </dependency>
-  </dependencies>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -49,4 +49,13 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>cloudbees-folder</artifactId>
+      <version>6.1.2</version>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.19</version>
+    <version>2.34</version>
     <relativePath/>
   </parent>
 
@@ -18,7 +18,6 @@
     <!-- TODO FIXME Adjust after release that dropped cc.xml from core -->
     <jenkins.version>2.41</jenkins.version>
     <java.level>7</java.level>
-    <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
   </properties>
 
   <name>CCtray XML (cc.xml) Plugin</name>

--- a/src/main/java/org/jenkinsci/plugins/ccxml/CCXMLAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ccxml/CCXMLAction.java
@@ -32,9 +32,7 @@ import hudson.model.View;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Stapler;
@@ -76,27 +74,26 @@ public class CCXMLAction implements Action {
      * as well. The map is keyed by the folder the item is in, with top-level
      * items having an empty key.
      */
-    public Map<String, Collection<TopLevelItem>> getItems() {
+    @Restricted(NoExternalUse.class)
+    public Collection<TopLevelItem> getItems() {
         String recursive = Stapler.getCurrentRequest().getParameter("recursive");
         if (recursive == null) {
-            return Collections.singletonMap("", view.getItems());
+            return view.getItems();
         } else {
-            return Collections.unmodifiableMap(getItemsRecursive("", view.getItems()));
+            return Collections.unmodifiableCollection(getItemsRecursive(view.getItems()));
         }
     }
 
-    private Map<String, Collection<TopLevelItem>> getItemsRecursive(String namePrefix, Collection<TopLevelItem> items) {
-        Map<String, Collection<TopLevelItem>> result = new HashMap<>();
-        List<TopLevelItem> currentLevelItems = new ArrayList<>();
+    private Collection<TopLevelItem> getItemsRecursive(Collection<TopLevelItem> items) {
+        List<TopLevelItem> result = new ArrayList<>();
         for (TopLevelItem i : items) {
             if (i instanceof ItemGroup) {
                 ItemGroup g = (ItemGroup) i;
-                result.putAll(getItemsRecursive(namePrefix + g.getDisplayName() + "/", g.getItems()));
+                result.addAll(getItemsRecursive(g.getItems()));
             } else {
-                currentLevelItems.add(i);
+                result.add(i);
             }
         }
-        result.put(namePrefix, currentLevelItems);
         return result;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ccxml/CCXMLAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ccxml/CCXMLAction.java
@@ -25,14 +25,11 @@ package org.jenkinsci.plugins.ccxml;
 
 import hudson.model.Action;
 import hudson.model.Item;
-import hudson.model.ItemGroup;
+import hudson.model.Items;
 import hudson.model.Job;
 import hudson.model.TopLevelItem;
 import hudson.model.View;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Stapler;
@@ -80,20 +77,8 @@ public class CCXMLAction implements Action {
         if (recursive == null) {
             return view.getItems();
         } else {
-            return Collections.unmodifiableCollection(getItemsRecursive(view.getItems(), new ArrayList<TopLevelItem>()));
+            return Items.getAllItems(view.getOwner().getItemGroup(), TopLevelItem.class);
         }
-    }
-
-    private List<TopLevelItem> getItemsRecursive(Collection<TopLevelItem> items, List<TopLevelItem> result) {
-        for (TopLevelItem i : items) {
-            if (i instanceof ItemGroup) {
-                ItemGroup g = (ItemGroup) i;
-                getItemsRecursive(g.getItems(), result);
-            } else {
-                result.add(i);
-            }
-        }
-        return result;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/ccxml/CCXMLAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ccxml/CCXMLAction.java
@@ -80,16 +80,15 @@ public class CCXMLAction implements Action {
         if (recursive == null) {
             return view.getItems();
         } else {
-            return Collections.unmodifiableCollection(getItemsRecursive(view.getItems()));
+            return Collections.unmodifiableCollection(getItemsRecursive(view.getItems(), new ArrayList<TopLevelItem>()));
         }
     }
 
-    private Collection<TopLevelItem> getItemsRecursive(Collection<TopLevelItem> items) {
-        List<TopLevelItem> result = new ArrayList<>();
+    private List<TopLevelItem> getItemsRecursive(Collection<TopLevelItem> items, List<TopLevelItem> result) {
         for (TopLevelItem i : items) {
             if (i instanceof ItemGroup) {
                 ItemGroup g = (ItemGroup) i;
-                result.addAll(getItemsRecursive(g.getItems()));
+                getItemsRecursive(g.getItems(), result);
             } else {
                 result.add(i);
             }

--- a/src/main/resources/org/jenkinsci/plugins/ccxml/CCXMLAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ccxml/CCXMLAction/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-    <st:contentType value="text/xml;charset=UTF-8" />
+    <st:contentType value="application/xml;charset=UTF-8" />
     <Projects>
         <j:forEach var="me" items="${it.items}">
             <j:forEach var="p" items="${me.value}">

--- a/src/main/resources/org/jenkinsci/plugins/ccxml/CCXMLAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ccxml/CCXMLAction/index.jelly
@@ -30,17 +30,19 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <st:contentType value="text/xml;charset=UTF-8" />
     <Projects>
-        <j:forEach var="p" items="${it.view.items}">
-            <j:set var="lb" value="${p.lastCompletedBuild}"/>
-            <j:if test="${lb!=null}">
-                <Project  name="${p.displayName}"
-                          activity="${p.isBuilding() ? 'Building' : 'Sleeping'}"
-                          lastBuildStatus="${it.toCCStatus(p)}"
-                          lastBuildLabel="${lb.number}"
-                          lastBuildTime="${lb.timestampString2}"
-                          webUrl="${app.rootUrl}${p.url}"
-                />
-            </j:if>
+        <j:forEach var="me" items="${it.items}">
+            <j:forEach var="p" items="${me.value}">
+                <j:set var="lb" value="${p.lastCompletedBuild}"/>
+                <j:if test="${lb!=null}">
+                    <Project  name="${me.key + p.displayName}"
+                              activity="${p.isBuilding() ? 'Building' : 'Sleeping'}"
+                              lastBuildStatus="${it.toCCStatus(p)}"
+                              lastBuildLabel="${lb.number}"
+                              lastBuildTime="${lb.timestampString2}"
+                              webUrl="${app.rootUrl}${p.url}"
+                    />
+                </j:if>
+            </j:forEach>
         </j:forEach>
     </Projects>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ccxml/CCXMLAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ccxml/CCXMLAction/index.jelly
@@ -28,21 +28,19 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-    <st:contentType value="application/xml;charset=UTF-8" />
+    <st:contentType value="text/xml;charset=UTF-8" />
     <Projects>
-        <j:forEach var="me" items="${it.items}">
-            <j:forEach var="p" items="${me.value}">
-                <j:set var="lb" value="${p.lastCompletedBuild}"/>
-                <j:if test="${lb!=null}">
-                    <Project  name="${me.key + p.displayName}"
-                              activity="${p.isBuilding() ? 'Building' : 'Sleeping'}"
-                              lastBuildStatus="${it.toCCStatus(p)}"
-                              lastBuildLabel="${lb.number}"
-                              lastBuildTime="${lb.timestampString2}"
-                              webUrl="${app.rootUrl}${p.url}"
-                    />
-                </j:if>
-            </j:forEach>
+        <j:forEach var="p" items="${it.items}">
+            <j:set var="lb" value="${p.lastCompletedBuild}"/>
+            <j:if test="${lb!=null}">
+                <Project  name="${p.fullDisplayName}"
+                          activity="${p.isBuilding() ? 'Building' : 'Sleeping'}"
+                          lastBuildStatus="${it.toCCStatus(p)}"
+                          lastBuildLabel="${lb.number}"
+                          lastBuildTime="${lb.timestampString2}"
+                          webUrl="${app.rootUrl}${p.url}"
+                />
+            </j:if>
         </j:forEach>
     </Projects>
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/ccxml/CCXMLActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ccxml/CCXMLActionTest.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 dnusbaum.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.ccxml;
+
+import com.gargoylesoftware.htmlunit.xml.XmlPage;
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import java.util.List;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockFolder;
+
+public class CCXMLActionTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testGetItemsNonRecursive() throws Exception {
+        FreeStyleProject p1 = j.createFreeStyleProject("project1");
+        j.buildAndAssertSuccess(p1);
+
+        XmlPage xml = getPrimaryViewCCXMLPage();
+        assertXPathNodeCount(xml, getXPathForItem(p1), 1);
+
+        MockFolder f1 = j.createFolder("folder1");
+        FreeStyleProject p2 = f1.createProject(FreeStyleProject.class, "project2");
+        j.buildAndAssertSuccess(p2);
+        xml = getPrimaryViewCCXMLPage();
+        assertXPathNodeCount(xml, getXPathForItem(p1), 1);
+        assertXPathNodeCount(xml, getXPathForItem(p2), 0);
+    }
+
+    @Test
+    public void testGetItemsRecursive() throws Exception {
+        FreeStyleProject p1 = j.createFreeStyleProject("project1");
+        j.buildAndAssertSuccess(p1);
+
+        XmlPage xml = getPrimaryViewCCXMLPage("recursive");
+        assertXPathNodeCount(xml, getXPathForItem(p1), 1);
+
+        MockFolder f1 = j.createFolder("folder1");
+        FreeStyleProject p2 = f1.createProject(FreeStyleProject.class, "project2");
+        j.buildAndAssertSuccess(p2);
+        xml = getPrimaryViewCCXMLPage("recursive");
+        assertXPathNodeCount(xml, getXPathForItem(p1), 1);
+        assertXPathNodeCount(xml, getXPathForItem(f1, p2), 1);
+
+        MockFolder f2 = f1.createProject(MockFolder.class, "folder2");
+        FreeStyleProject p3 = f2.createProject(FreeStyleProject.class, "project3");
+        j.buildAndAssertSuccess(p3);
+        xml = getPrimaryViewCCXMLPage("recursive");
+        assertXPathNodeCount(xml, getXPathForItem(p1), 1);
+        assertXPathNodeCount(xml, getXPathForItem(f1, p2), 1);
+        assertXPathNodeCount(xml, getXPathForItem(f1, f2, p3), 1);
+    }
+
+    private XmlPage getPrimaryViewCCXMLPage(String... queryParameters) throws Exception {
+        return j.createWebClient().goToXml("view/all/" + CCXMLAction.URL_NAME + "/?" + String.join("&", queryParameters));
+    }
+
+    private void assertXPathNodeCount(XmlPage xml, String xPath, int expectedNodes) {
+        List<?> nodes = xml.getByXPath(xPath);
+        assertEquals("incorrect number of nodes in xpath", expectedNodes, nodes.size());
+    }
+
+    private String getXPathForItem(Item... pathToItem) {
+        String[] itemNames = new String[pathToItem.length];
+        for (int i = 0; i < pathToItem.length; i++) {
+            itemNames[i] = pathToItem[i].getDisplayName();
+        }
+        return "/Projects/Project[@name='" + String.join("/", itemNames) + "']";
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/ccxml/CCXMLActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ccxml/CCXMLActionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2017 dnusbaum.
+ * Copyright 2017 CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
[JENKINS-36282](https://issues.jenkins-ci.org/browse/JENKINS-36282)

I added the ability to specify a query parameter to list all jobs recursively in cc.xml. I made it optional in case someone relies on the current behavior, but if that isn't an issue we could just make the recursive behavior a non-optional default.

The name of jobs in folders are prefixed by the folder name, i.e. `<Project ... name="Folder1/Project1">`, so I believe this also fixes [JENKINS-34641](https://issues.jenkins-ci.org/browse/JENKINS-34641).

@reviewbybees