### PR TITLE
Use build display name as the CC XML "Last Build Label"

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/cctrayxml/CCTrayXmlAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cctrayxml/CCTrayXmlAction/index.jelly
@@ -36,7 +36,7 @@ THE SOFTWARE.
                 <Project  name="${p.fullDisplayName}"
                           activity="${p.isBuilding() ? 'Building' : 'Sleeping'}"
                           lastBuildStatus="${it.toCCStatus(p)}"
-                          lastBuildLabel="${lb.number}"
+                          lastBuildLabel="${lb.displayName}"
                           lastBuildTime="${lb.timestampString2}"
                           webUrl="${app.rootUrl}${p.url}"
                 />


### PR DESCRIPTION
At our organisation, we set the build display name for our jobs to represent a version number, with the build number used as the third component, like so: `"2.10.${BUILD_NUMBER}"`

These builds always show up in the Jenkins web interface with the display name like so:
![Jenkins build history with display names](https://user-images.githubusercontent.com/844245/39812325-1ce5957e-5384-11e8-8413-50dc1a3872e6.png)

However, using CCTray pointing at Jenkins' `/cc.xml`, the build label only shows the build number:
![CCTray showing build numbers as labels](https://user-images.githubusercontent.com/844245/39814390-f16c95fc-538b-11e8-869f-ddb06de6e479.png)
(**Expected:** "2.10.104", **Actual:** "104")

This PR changes the cc.xml action to use the build's Display Name instead of its Build Number to use as the "Last Build Label" in CCTray. I think this better suits what should be shown for the label (and what we're used to being able to customise in CruiseControl.NET), however it is a change from the existing format, so it may require a breaking version increment or a possibility to be optional.