### PR TITLE
Modernize the plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.42</version>
+    <version>4.37</version>
     <relativePath />
   </parent>
 
@@ -13,28 +13,29 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.173</jenkins.version>
+    <jenkins.version>2.289.1</jenkins.version>
     <java.level>8</java.level>
     <revision>1.1</revision>
     <changelist>-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
   <name>CCtray XML (cc.xml) Plugin</name>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/CCtray+XML+Plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   <version>${revision}${changelist}</version>
 
   <licenses>
     <license>
       <name>MIT License</name>
-      <url>http://opensource.org/licenses/MIT</url>
+      <url>https://opensource.org/licenses/MIT</url>
     </license>
   </licenses>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <connection>scm:git:https://github.com/${gitHubRepo}</connection>
+    <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
     <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
 
   <repositories>

--- a/src/main/resources/org/jenkinsci/plugins/cctrayxml/CCTrayXmlPageDecorator/footer.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cctrayxml/CCTrayXmlPageDecorator/footer.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 Behaviour.addLoadEvent(function() {
         var rssbar = document.getElementById('rss-bar')
         if (typeof rssbar !== 'undefined' && rssbar !== null) {
-            rssbar.insertAdjacentHTML('beforeend', ' <a href="cc.xml/"><img src="${resURL}/images/16x16/text.png"/> cc.xml</a> (<a href="cc.xml/?recursive">recursive</a>)');
+            rssbar.insertAdjacentHTML('beforeend', ' <a href="cc.xml/" class="yui-button link-button"><img src="${resURL}/images/16x16/text.png" class="leading-icon" /> cc.xml</a> <a href="cc.xml/?recursive" class="yui-button link-button"><img src="${resURL}/images/16x16/text.png" class="leading-icon" /> recursive cc.xml</a></a>');
         }
 });//]]>
     </script>


### PR DESCRIPTION
The usual:
* Update parent POM
* Update core baseline to drop a few implied dependencies
* Fix URL to no longer reference the wiki

This also updates the UI to match recent Jenkins releases:

## Before
### 2.289.1
<img width="1375" alt="Screenshot" src="https://user-images.githubusercontent.com/1831569/156378767-fd5ca7f1-8097-482b-b96f-8159903b43b8.png">

### 2.336
<img width="1383" alt="Screenshot" src="https://user-images.githubusercontent.com/1831569/156378638-dc233282-70e4-4e0c-8616-4ff204379757.png">


## After
### 2.289.1
<img width="1599" alt="Screenshot" src="https://user-images.githubusercontent.com/1831569/156378153-3a1ed2c7-0997-41eb-bed4-f5e3efff8a10.png">

### 2.336
<img width="1624" alt="Screenshot" src="https://user-images.githubusercontent.com/1831569/156378168-9f979278-ca03-42cd-84de-60dea06d7e57.png">

It's a bit weird that the default font size in this bar is different from that of all of its children but 🤷
 