### PR TITLE
Use SVG Icon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.37</version>
+    <version>4.38</version>
     <relativePath />
   </parent>
 
@@ -13,7 +13,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.289.1</jenkins.version>
+    <jenkins.version>2.346</jenkins.version>
     <java.level>8</java.level>
     <revision>1.2</revision>
     <changelist>-SNAPSHOT</changelist>

--- a/src/main/resources/org/jenkinsci/plugins/cctrayxml/CCTrayXmlPageDecorator/footer.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cctrayxml/CCTrayXmlPageDecorator/footer.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 Behaviour.addLoadEvent(function() {
         var rssbar = document.getElementById('rss-bar')
         if (typeof rssbar !== 'undefined' && rssbar !== null) {
-            rssbar.insertAdjacentHTML('beforeend', ' <a href="cc.xml/" class="yui-button link-button"><img src="${resURL}/images/16x16/text.png" class="leading-icon" /> cc.xml</a> <a href="cc.xml/?recursive" class="yui-button link-button"><img src="${resURL}/images/16x16/text.png" class="leading-icon" /> recursive cc.xml</a></a>');
+            rssbar.insertAdjacentHTML('beforeend', ' <a href="cc.xml/" class="yui-button link-button"><img src="${resURL}/plugin/cctray-xml/images/svgs/Icon-txt.svg" class="leading-icon" height="16px"/> cc.xml</a> <a href="cc.xml/?recursive" class="yui-button link-button"><img src="${resURL}/plugin/cctray-xml/images/svgs/Icon-txt.svg" class="leading-icon" height="16px"/> recursive cc.xml</a></a>');
         }
 });//]]>
     </script>

--- a/src/main/webapp/images/svgs/Icon-txt.svg
+++ b/src/main/webapp/images/svgs/Icon-txt.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3800 4800">
+ <g><path fill="#EEE" d="M0 4800h3800V840L2960 0H0"/><path fill="#BBB" d="M2960 840h840L2960 0"/><path fill="#888" d="M3800 1680V840h-840"/></g>
+ <g><path fill="#555" d="M900 1976h2000v-212H900m0 670h2000v-211H900m0 670h2000v-212H900m0 635h1200v-176H900"/></g>
+</svg>


### PR DESCRIPTION
As of LTS 2.346.x, the old icons are no longer present.

This change brings in a similar-looking icon as SVG.

Refs: JENKINS-69138

This is in 2.332.4
<img width="998" alt="image" src="https://user-images.githubusercontent.com/193047/181056618-1148aff6-ab5b-4762-a963-9075f9501eab.png">

This is in 2.346.2
<img width="983" alt="image" src="https://user-images.githubusercontent.com/193047/181056684-c4a80a0c-9081-4e56-b4bc-d95b1754b7d0.png">

This is what this PR does on 2.346
<img width="956" alt="image" src="https://user-images.githubusercontent.com/193047/181056772-7b98aa8b-42df-4170-953d-075fc46dd801.png">


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
