### PR TITLE
feat: mark extensions as dynamically loadable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cctrayxml/CCTrayXmlActionFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/cctrayxml/CCTrayXmlActionFactory.java
@@ -27,13 +27,14 @@ import hudson.Extension;
 import hudson.model.Action;
 import hudson.model.TransientViewActionFactory;
 import hudson.model.View;
+import jenkins.YesNoMaybe;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.util.Collections;
 import java.util.List;
 
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 @Restricted(NoExternalUse.class)
 public class CCTrayXmlActionFactory extends TransientViewActionFactory {
     @Override

--- a/src/main/java/org/jenkinsci/plugins/cctrayxml/CCTrayXmlPageDecorator.java
+++ b/src/main/java/org/jenkinsci/plugins/cctrayxml/CCTrayXmlPageDecorator.java
@@ -2,8 +2,9 @@ package org.jenkinsci.plugins.cctrayxml;
 
 import hudson.Extension;
 import hudson.model.PageDecorator;
+import jenkins.YesNoMaybe;
 
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class CCTrayXmlPageDecorator extends PageDecorator {
     // footer.jelly
 }


### PR DESCRIPTION
## Summary

- Set `dynamicLoadable = YesNoMaybe.YES` on both `@Extension` annotations (`CCTrayXmlActionFactory` and `CCTrayXmlPageDecorator`)

## Why

Without an explicit `dynamicLoadable` value, Jenkins defaults to `MAYBE`, which prompts users to choose between restarting Jenkins or dynamically loading the plugin during installation. Since both extensions are stateless and have no complex initialization, they are safe for dynamic loading. Setting `YES` lets Jenkins hot-load the plugin without prompting, improving the installation experience.

## Test plan

- [x] `mvn verify` passes